### PR TITLE
Clarify Cordova plugin testing info

### DIFF
--- a/doc/api/widgets/Widget.json
+++ b/doc/api/widgets/Widget.json
@@ -99,7 +99,7 @@
     },
     "layoutData": {
       "type": "LayoutData",
-      "description": "Specifies how the widget should be arranged in a layout. See [Layout](layout.md)."
+      "description": "Specifies how the widget should be arranged in a layout. See [Layout](../layout.md)."
     },
     "font": {
       "type": "Font",
@@ -197,7 +197,7 @@
         {"name": "widget", "type": "Widget"},
         {"name": "gesture", "type": "TouchEvent"}
       ],
-      "description": "Fired when a widget is touched. See [Touch Events](touch.md)."
+      "description": "Fired when a widget is touched. See [Touch Events](../touch.md)."
     },
     "touchmove": {
       "parameters": [

--- a/doc/cordova.md
+++ b/doc/cordova.md
@@ -17,7 +17,7 @@ While using the [Tabris.js Developer App](getting-started.md), your application 
 These plug-ins have tested with Tabris.js and a [demo](https://github.com/eclipsesource/tabris-js/tree/master/examples/cordova) can be found among the Tabris.js examples.
 
 ## Other Cordova Plug-Ins
-To use Cordova Plug-Ins not part of the Developer App you need to add them during the [build](build.md) process. Plug-Ins that are added during the build process cannot be tested with the Developer App.
+To use Cordova Plug-Ins not part of the Developer App you need to add them during the [build](build.md) process. Once you have created a build, you can continue to load new application code using the developer console if you set the build setting *debug* mode to `ON` and `EnableDeveloperConsole` to `true` in your [`config.xml`](build.md#configuration).
 
 Most of the Plug-Ins will work out of the box but not all. This is because Tabris.js uses a **native UI** and **no HTML5**. As a result all Plug-Ins that manipulate the DOM will not work.
 

--- a/doc/cordova.md
+++ b/doc/cordova.md
@@ -13,6 +13,10 @@ While using the [Tabris.js Developer App](getting-started.md), your application 
 * [Network Information](http://plugins.cordova.io/#/package/org.apache.cordova.network-information)
 * [Toast](http://plugins.cordova.io/#/package/nl.x-services.plugins.toast)
 * [Touch Id](http://plugins.cordova.io/#/package/io.monaca.touchid)
+* [BarcodeScanner](http://plugins.cordova.io/#/package/com.phonegap.plugins.barcodescanner)
+* [Device motion](http://plugins.cordova.io/#/package/org.apache.cordova.device-motion)
+* [Google Analytics](http://plugins.cordova.io/#/package/com.cmackay.plugins.googleanalytics)
+* [Google Play Services](http://plugins.cordova.io/#/package/com.google.playservices)
 
 These plug-ins have tested with Tabris.js and a [demo](https://github.com/eclipsesource/tabris-js/tree/master/examples/cordova) can be found among the Tabris.js examples.
 

--- a/doc/cordova.md
+++ b/doc/cordova.md
@@ -17,6 +17,8 @@ While using the [Tabris.js Developer App](getting-started.md), your application 
 These plug-ins have tested with Tabris.js and a [demo](https://github.com/eclipsesource/tabris-js/tree/master/examples/cordova) can be found among the Tabris.js examples.
 
 ## Other Cordova Plug-Ins
-To use Cordova Plug-Ins not part of the Developer App you need to add them during the [build](build.md) process. Most of the Plug-Ins will work out of the box but not all. This is because Tabris.js uses a **native UI** and **no HTML5**. As a result all Plug-Ins that manipulate the DOM will not work.
+To use Cordova Plug-Ins not part of the Developer App you need to add them during the [build](build.md) process. Plug-Ins that are added during the build process cannot be tested with the Developer App.
+
+Most of the Plug-Ins will work out of the box but not all. This is because Tabris.js uses a **native UI** and **no HTML5**. As a result all Plug-Ins that manipulate the DOM will not work.
 
 Plug-Ins that have been tested with Tabris.js are tracked as [GitHub issues](https://github.com/eclipsesource/tabris-js/issues?utf8=%E2%9C%93&q=label%3A%22compatibility+cordova%22). If the Plug-In is confirmed to work the issue is closed. Please feel free to add issues for Plug-Ins that you tested.


### PR DESCRIPTION
Until I started reading responses in various issues it wasn't clear to me that you need to build the app in order to test any Cordova plugins that aren't already built in.  This PR is simply to update the docs to make that fact a little more explicit.

On a related note, is it technically possible to pull in plugins at runtime from within the developer app?  In other words, is this something that could be possible in a future version?  One of the greatest features of Tabris.js is the ability to rapidly see code changes on a device, and if an app relies on a Cordova plugin it just makes the process longer to have to build it every time you need to fix a typo.