### PR TITLE
Clear Webview URL as part of the dispose sequence.

### DIFF
--- a/src/tabris/Widgets.js
+++ b/src/tabris/Widgets.js
@@ -624,6 +624,14 @@
     _properties: {
       url: {type: "string", nocache: true},
       html: {type: "string", nocache: true}
+    },
+    _create: function(properties) {
+      this._on("dispose", function(){
+        this.set('url','');
+        this.set('html','');
+      });
+      this.super("_create", properties);
+      return this;
     }
   });
 


### PR DESCRIPTION
Hey, just stumbled across this awesome project!

This PR fixes an annoying issue that Webviews are not really disposed when dispose is called (which can be damaging in various ways like leaking memory, playing sounds in the background and more).

Want to see an example ? 
In the REDDIT example go to reddit.js line 120 and change:
tabris.create("WebView", {
  layoutData: {left: 0, top: 0, right: 0, bottom: 0},
  url: data.url
}).appendTo(detailPage);

to: 
tabris.create("WebView", {
  layoutData: {left: 0, top: 0, right: 0, bottom: 0},
  url: 'https://m.youtube.com/watch?v=8SbUC-UaAxE'  // Guns N' Roses - November Rain
}).appendTo(detailPage);

When you run it now, visit the page, play the video and go back. You can see the list but the song is still playing in the background. You can even open another frame and have two youtube players playing simultaneously. 
The only way to shut the frame (and sound) down is quitting the app.

Hope this helps.