### PR TITLE
Fix fetch example

### DIFF
--- a/examples/fetch/fetch.js
+++ b/examples/fetch/fetch.js
@@ -15,10 +15,12 @@ var createTextView = function(text) {
   }).appendTo(page);
 };
 
-fetch("http://www.telize.com/geoip").then(function(response) {
+fetch("https://freegeoip.net/json/").then(function(response) {
   return response.json();
 }).then(function(json) {
   createTextView("The IP address is: " + json.ip);
+  createTextView("City: " + json.city);
+  createTextView("Country: " + json.country_name);
   createTextView("Latitude: " + json.latitude);
   createTextView("Longitude: " + json.longitude);
 });


### PR DESCRIPTION
The public API of telize.com has been permanently shut down as of November 15th, 2015. More information can be found [http://www.cambus.net/adventures-in-running-a-free-public-api/](here).

This pull request switches to freegeoip.net and fixes #701.