### PR TITLE
Add documentation for Android debuggers

### DIFF
--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,0 +1,7 @@
+# Debugging Tabris.js
+Tabris.js supports the `console.log`, `info`, `warn`, and `error` functions that are useful for debugging.  However for more complex applications it is often perferred to use a full-fledged debugger, allowing the developer to pause script execution by setting breakpoints, allowing the inspection and redefinition of variables currently in scope.  Tabris.js supports several debuggers:
+
+## Android
+You can [Debug your app using Chrome Developer Tools](http://eclipsesource.com/blogs/2016/06/06/debugging-javascript-with-tabris-js/) without installing any special software.  Alternatively, you can use Eclipse to debug your app.  To do so you will need to use the Android Debug Bridge (ADB) from the [Android SDK Platform Tools](https://developer.android.com/studio/releases/platform-tools.html).  After installing the platform tools you will need to [set up your device for debugging](https://developer.android.com/studio/command-line/adb.html#Enabling).  Once set up you can follow the instructions to [debug your app using Eclipse](http://eclipsesource.com/blogs/2015/04/17/debugging-tabris-js/).
+
+> <img align="left" src="img/note.png"> The console log output is also printed to the `logcat` console on when your app is build in debug mode.  The output can be viewed from the host machine by typing `adb logcat`.

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,7 +32,7 @@ Tabris.js is a mobile framework that lets you develop native iOS and Android app
 
 ## Articles
 - [Apache Cordova vs. Tabris.js](http://eclipsesource.com/blogs/2015/03/02/apache-cordova-vs-tabris-js/) - How to use Cordova's build tooling to create Tabris.js apps.
-- [Debugging Tabris.js](http://eclipsesource.com/blogs/2015/04/17/debugging-tabris-js/) - How to debug a Tabris.js app running on Android using Eclipse.
+- [Debugging Tabris.js](debug.md) - How to debug a Tabris.js app
 - [Layouting in Tabris.js](http://eclipsesource.com/blogs/2015/02/19/layouting-in-tabris-js/) - Layouting explained.
 - [CollectionView: Display Data Sets in Tabris.js](http://eclipsesource.com/blogs/2015/02/16/collectionview-display-data-sets-in-tabris-js/) - The power of the CollectionView in detail.
 


### PR DESCRIPTION
Continuation of #1173 (rebasing a fork is no fun).

The current documentation for debugging is just a link to the Android/Chrome Developer Tools blog post.  Create a new page with a brief overview of debuggers and information about the Android debuggers.  Information on iOS and Windows debugging to be added in a separate commit.