### PR TITLE
Add note to platform download docs to sign in

### DIFF
--- a/doc/local-build.md
+++ b/doc/local-build.md
@@ -19,7 +19,7 @@ The Tabris CLI uses Cordova to build apps, so you also need a Cordova installati
 
 ### Downloading Tabris.js platforms
 
-Tabris.js ships custom Cordova platforms for Android, iOS, and Windows. Visit the [Tabris.js download page](https://tabrisjs.com/download) and download the platform of your choice.
+Tabris.js ships custom Cordova platforms for Android, iOS, and Windows. Visit the [Tabris.js download page](https://tabrisjs.com/download) and download the platform of your choice (make sure to sign in to Tabrisjs.com).
 
 Extract the content of the downloaded archive and create an environment variable `TABRIS_ANDROID_PLATFORM`, `TABRIS_IOS_PLATFORM`, or `TABRIS_WINDOWS_PLATFORM`, respectively, that contains the path to the extracted folder.
 


### PR DESCRIPTION
As mentioned in #1111 and #1215, you must be signed in to download the Cordova platforms to perform a local build.