### PR TITLE
Update examples to set properties directly

### DIFF
--- a/examples/bookstore/bookstore.js
+++ b/examples/bookstore/bookstore.js
@@ -43,8 +43,8 @@ new tabris.CollectionView({
   },
   updateCell: (view, index) => {
     let page = pageConfigurations[index];
-    view.find('#bookImage').set('image', page.image);
-    view.find('#bookTitle').set('text', page.title);
+    view.find('#bookImage').image = page.image;
+    view.find('#bookTitle').text = page.title;
   }
 }).on('select', ({index}) => {
   tabris.ui.drawer.close();
@@ -164,9 +164,9 @@ function createBooksList(books) {
     },
     updateCell: (view, index) => {
       let book = books[index];
-      view.find('#bookImage').set('image', book.image);
-      view.find('#bookTitle').set('text', book.title);
-      view.find('#bookAuthor').set('text', book.author);
+      view.find('#bookImage').image = book.image;
+      view.find('#bookTitle').text = book.title;
+      view.find('#bookAuthor').text = book.author;
     }
   }).on('select', ({index}) => createBookPage(books[index]).appendTo(navigationView));
 }
@@ -232,5 +232,5 @@ function createLicenseWebviewPage() {
 }
 
 function actionVisbility(isVisible) {
-  tabris.ui.children('#licenseToggler').set('visible', isVisible);
+  tabris.ui.children('#licenseToggler').visible = isVisible;
 }

--- a/examples/canvas/animation.js
+++ b/examples/canvas/animation.js
@@ -4,7 +4,7 @@ var page = module.exports = new tabris.Page({
   title: 'Animation',
   autoDispose: false
 }).on('disappear', function() {
-  page.children('#animateCheckBox').set('checked', false);
+  page.children('#animateCheckBox').checked = false;
 });
 
 new tabris.Canvas({

--- a/examples/i18n/i18n.js
+++ b/examples/i18n/i18n.js
@@ -63,9 +63,9 @@ class MenuCell extends tabris.Composite {
   }
 
   set dish(dish) {
-    this.find('#priceText').set('text', dish.price);
-    this.find('#nameText').set('text', dish.name);
-    this.find('#descriptionText').set('text', dish.description);
+    this.find('#priceText').text = dish.price;
+    this.find('#nameText').text = dish.name;
+    this.find('#descriptionText').text = dish.description;
   }
 
 }

--- a/examples/input/input.js
+++ b/examples/input/input.js
@@ -95,7 +95,7 @@ new tabris.Composite({
   new tabris.Slider({
     id: 'luggageSlider'
   }).on('selectionChanged', ({value}) => {
-    scrollView.find('#luggageWeight').set('text', value + ' Kg');
+    scrollView.find('#luggageWeight').text = value + ' Kg';
   })
 ).appendTo(scrollView);
 

--- a/examples/reddit/reddit.js
+++ b/examples/reddit/reddit.js
@@ -29,10 +29,10 @@ let collectionView = new tabris.CollectionView({
     let item = items[index];
     if (!(item.loading)) {
       view.find('#container').first().item = item;
-      view.find('#itemImage').set('image', {src: item.data.thumbnail, width: 80, height: 80});
-      view.find('#nameText').set('text', item.data.title);
-      view.find('#commentText').set('text', item.data.num_comments + ' comments');
-      view.find('#authorText').set('text', item.data.author);
+      view.find('#itemImage').image = {src: item.data.thumbnail, width: 80, height: 80};
+      view.find('#nameText').text = item.data.title;
+      view.find('#commentText').text = item.data.num_comments + ' comments';
+      view.find('#authorText').text = item.data.author;
     }
   }
 }).on('refresh', loadNewItems)

--- a/examples/swipe-to-dismiss/swipe-to-dismiss.js
+++ b/examples/swipe-to-dismiss/swipe-to-dismiss.js
@@ -46,9 +46,9 @@ let collectionView = new tabris.CollectionView({
   updateCell: (view, index) => {
     let item = items[index];
     view.find('#container').first().item = item;
-    view.find('#senderText').set('text', item.sender);
-    view.find('#titleText').set('text', item.title);
-    view.find('#timeText').set('text', item.time);
+    view.find('#senderText').text = item.sender;
+    view.find('#titleText').text = item.title;
+    view.find('#timeText').text = item.time;
   }
 }).appendTo(tabris.ui.contentView);
 

--- a/snippets/collectionview-cellheightauto.js
+++ b/snippets/collectionview-cellheightauto.js
@@ -30,5 +30,5 @@ new tabris.CollectionView({
     }).appendTo(composite);
     return composite;
   },
-  updateCell: (cell, index) => cell.find('#textView').set('text', items[index])
+  updateCell: (cell, index) => cell.find('#textView').text = items[index]
 }).appendTo(tabris.ui.contentView);

--- a/snippets/device.js
+++ b/snippets/device.js
@@ -9,5 +9,5 @@
 });
 
 tabris.device.on('orientationChanged', function({value: orientation}) {
-  tabris.ui.contentView.find('#orientation').set('text', 'orientation: ' + orientation);
+  tabris.ui.contentView.find('#orientation').text = 'orientation: ' + orientation;
 });

--- a/snippets/imageview-load.js
+++ b/snippets/imageview-load.js
@@ -27,5 +27,5 @@ new tabris.TextView({
 }).appendTo(tabris.ui.contentView);
 
 function handleLoad({target, error}) {
-  tabris.ui.contentView.find('#label-' + target.id).set('text', error ? 'Error' : 'Success');
+  tabris.ui.contentView.find('#label-' + target.id).text = error ? 'Error' : 'Success';
 }


### PR DESCRIPTION
- [X] Code is up-to-date with current `master`
- [X] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

With 2.x, properties are encouraged to be set directly rather than with getters/setters.  This PR updates snippets and examples that used the `set` method for a single property at a time.  There are some files that still utilize the `set` method that have not been changed as these occurrences call `set` with an object to set multiple properties at once.