### PR TITLE
Add windows to device.platform documentation

### DIFF
--- a/doc/api/device.json
+++ b/doc/api/device.json
@@ -15,7 +15,7 @@
         "iOS",
         "windows"
       ],
-      "description": "The name of the platform. Currently either `\"Android\"` or `\"iOS\"`. This property is also available globally as `device.platform`."
+      "description": "The name of the platform. Currently either `\"Android\"`, `\"iOS\"`, or `\"windows\"`. This property is also available globally as `device.platform`."
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

Update the documentation for `device.platform` to include Windows.  The description doesn't include all the supported values, and since the supported values are explicitly called out I'm not sure if this sentence is even necessary.

Some of the other paramaters could be updated for Windows:
* I'm not sure how `version` is calculated.  I see `10.0.` followed by the build number on Windows 10 Pro.  Not sure what a phone or tablet will show.
* `screenHeight` and `screenWidth` actually return the height/width of the window, which is often different than the screen height and width on non-phones.

`model` returns the same thing as `wmic computersystem get model`.  This one is self-explanatory and doesn't need to be updated, although a separate issue could be raised to include the manufacturer since the model number may be a manufacturer-specific code.