### PR TITLE
Update WebView docs to clarify anchor navigation

### DIFF
--- a/doc/api/widgets/WebView.json
+++ b/doc/api/widgets/WebView.json
@@ -38,7 +38,7 @@
       "description": "Fired when the WebView is about to navigate to a new URL.",
       "parameters": {
         "preventDefault": {
-          "description": "Call to intercept the navigation.",
+          "description": "Call to intercept the navigation.  Not possible when the event is only an anchor navigation",
           "type": "() => void"
         },
         "url": {


### PR DESCRIPTION
As discussed in #828 it is not possible for the `navigate` event to fire when the anchor changes.

- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)