### PR TITLE
Add $IS_DEBUG to allowed values for EnableDeveloperConsole

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -195,7 +195,7 @@ In addition to the settings described in the [Cordova config.xml Guide](http://c
 
 | Name                   | Allowed Values | Default Value | Description |
 |------------------------|----------------|---------------|-------------|
-| EnableDeveloperConsole | true/false     | false         | Enables/Disables the [Tabris.js Developer Console](getting-started.md#the-developer-console).             |
+| EnableDeveloperConsole | true/false     | false         | Enables/Disables the [Tabris.js Developer Console](getting-started.md#the-developer-console). Setting the value to `$IS_DEBUG` will make the value follow the value for [debug mode](#settings)|
 | UseStrictSSL           | true/false     | true          | Activate/Deactivate SSL certificate validation on [XHR](w3c-api.md#xmlhttprequest). When disabled self signed SSL certificates are accepted. Should be enabled in production. |
 
 Example:


### PR DESCRIPTION
- [X] Code is up-to-date with current `master`
- [X] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

As far as I can tell, this isn't documented anywhere except https://github.com/eclipsesource/tabris-js/issues/1375#issuecomment-308172055