### PR TITLE
[doc] Mark device properties as static

### DIFF
--- a/doc/api/device.json
+++ b/doc/api/device.json
@@ -15,36 +15,43 @@
         "iOS",
         "windows"
       ],
+      "static": true,
       "description": "The name of the platform. Currently either `\"Android\"`, `\"iOS\"`, or `\"windows\"`. This property is also available globally as `device.platform`."
     },
     "version": {
       "type": "string",
       "readonly": true,
+      "static": true,
       "description": "The platform version. On iOS it looks like this: `\"8.1.1\"`. On Android, the [version code](https://developer.android.com/reference/android/os/Build.VERSION_CODES.html) is returned. This property is also available globally as `device.version`."
     },
     "model": {
       "type": "string",
       "readonly": true,
+      "static": true,
       "description": "The name of the device model. For example `\"iPad4,1\"` or `\"Nexus 7\"`. This property is also available globally as `device.model`."
     },
     "language": {
       "type": "string",
       "readonly": true,
+      "static": true,
       "description": "The user language configured on the device as an [RFC 4646](http://tools.ietf.org/html/rfc4646) compliant string. For example `\"de\"`, `\"es-ES\"`, etc. This property is also available globally as `navigator.language`."
     },
     "screenWidth": {
       "type": "number",
       "readonly": true,
+      "static": true,
       "description": "The entire width of the device's screen in device independent pixel. Depends on the current device orientation. This property is also available as globally as [screen.width](https://developer.mozilla.org/en-US/docs/Web/API/Screen.width)."
     },
     "screenHeight": {
       "type": "number",
       "readonly": true,
+      "static": true,
       "description": "The entire height of the device's screen in device independent pixel. Depends on the current device orientation. This property is also available globally as [screen.height](https://developer.mozilla.org/en-US/docs/Web/API/Screen.height)."
     },
     "scaleFactor": {
       "type": "number",
       "readonly": true,
+      "static": true,
       "description": "The ratio between physical pixels and device independent pixels. This property is also available globally as [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window.devicePixelRatio)."
     },
     "orientation": {


### PR DESCRIPTION
The `language`, `model`, `platform`, `scaleFactor`, `screenHeight`, `screenWidth`, and `version` properties have auto-generated change events listed in [the docs](https://tabrisjs.com/documentation/latest/api/device.html).  Seeing these made me audibly laugh out loud.  Since none of these properties can change at runtime, these properties should be marked as static so auto-generated change events are not added to the documentation.  I don't have a capable device to determine if `win_keyboardPresent` or `win_primaryInput` actually fire events.


- [X] Code is up-to-date with current `master`
- [X] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)