### PR TITLE
[doc] Escape property types containing a pipe

### DIFF
--- a/grunt/grunt-generate-doc.js
+++ b/grunt/grunt-generate-doc.js
@@ -342,10 +342,9 @@ exports.generateDoc = function generateDoc({files, targetPath, version}) {
   }
 
   function renderTypeLink(name) {
-    if (!typeLinks[name]) {
-      return name;
-    }
-    return `[${name}](${typeLinks[name]})`;
+    return name.split('|')
+      .map(name => typeLinks[name] ? `[${name}](${typeLinks[name]})` : name)
+      .join('\\|');
   }
 
 };


### PR DESCRIPTION
The documentation contains a pipe character (`|`) to denote multiple types that can be set or returned for a property.  This is also the character that Markdown uses to denote the boundaries between table cells.  Markdown only uses the separator between cells, and not at the start of a row, so the string "number|string" would be parsed as a table row.  Instead, split the types by a pipe, render links as appropriate, and then join the types together with an escaped pipe to prevent table rendering.

![image](https://user-images.githubusercontent.com/1888809/29399804-8dc5afb6-82df-11e7-9604-79d6770d016f.png)

- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)