### PR TITLE
Use clearer error message on DateDialog type error

### DIFF
--- a/src/tabris/DateDialog.js
+++ b/src/tabris/DateDialog.js
@@ -49,6 +49,6 @@ function setDate(name, value) {
     this._nativeSet(name, value.getTime());
     this._storeProperty(name, value);
   } else {
-    throw new Error('date is not of type Date');
+    throw new Error(`${name} is not of type Date`);
   }
 }


### PR DESCRIPTION
- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

The message `date is not of type Date` is not very clear when setting both a `minDate` and a `maxDate` simultaneously in a constructor.

Submitting this against master; would love to see this cherry picked to `2.x` as well.