### PR TITLE
Add documentation for device.language discrepancy

### DIFF
--- a/doc/api/device.json
+++ b/doc/api/device.json
@@ -48,7 +48,7 @@
       "type": "string",
       "readonly": true,
       "const": true,
-      "description": "The user language configured on the device as an [RFC 4646](http://tools.ietf.org/html/rfc4646) compliant string. For example `\"de\"`, `\"es-ES\"`, etc. This property is also available globally as `navigator.language`."
+      "description": "The user language configured on the device as an [RFC 4646](http://tools.ietf.org/html/rfc4646) compliant string. For example `\"de\"`, `\"es-ES\"`, etc. This property is also available globally as `navigator.language`.  Note: On iOS ≥ 11 it will only return languages declared in [CFBundleLocalizations](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-109552-TPXREF111)."
     },
     "screenWidth": {
       "type": "number",


### PR DESCRIPTION
- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

As noted in #1756, `device.language` can return unexpected values.  Update the documentation to reflect this.

I'm on the fence as to whether or not to link to the issue's resolution comment; anyone without Cordova iOS development experience will surely be stumped as how to add the relevant strings.
