### PR TITLE
Doc: Update Cordova platform versions

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -51,11 +51,12 @@ One way to put it is "Tabris.js is Cordova with native widgets instead of HTML".
 
 ### What Cordova platform versions is Tabris.js based on?
 
-|               | Android   | iOS           | Windows |
-|---------------|-----------|---------------|---------|
-| Tabris.js 1.x | 5.2.2     | 4.5.4         | N/A     |
-| Tabris.js 2.x | 6.2 - 6.3 | 4.5.4 - 5.0.0 | 5.0.0   |
-| Tabris.js 3.x | 8.0       | 5.0.0         | N/A     |
+|                         | Android   | iOS           | Windows |
+|-------------------------|-----------|---------------|---------|
+| Tabris.js 1.x           | 5.2.2     | 4.5.4         | N/A     |
+| Tabris.js 2.x           | 6.2 - 6.3 | 4.5.4 - 5.0.0 | 5.0.0   |
+| Tabris.js 3.0.0 - 3.7.2 | 8.0       | 5.0.0         | N/A     |
+| Tabris.js 3.8.0 and up  | 9.0       | 5.0.0         | N/A     |
 
 ### Is Tabris.js based on Java?
 


### PR DESCRIPTION
- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)

As mentioned in [the release announcement](https://tabris.com/tabris-3-8-released/) 3.8.0 uses Cordova 9.0