### PR TITLE
Support generating and importing ECDSA keys

### DIFF
--- a/doc/api/CryptoKey.json
+++ b/doc/api/CryptoKey.json
@@ -23,7 +23,7 @@
       "type": {
         "map": {
           "name": {
-            "type": "'ECDH'"
+            "type": { "union": ["'ECDH'", "'ECDSA'"] }
           },
           "namedCurve": {
             "type": "'P-256'"

--- a/doc/api/SubtleCrypto.json
+++ b/doc/api/SubtleCrypto.json
@@ -287,7 +287,9 @@
               {
                 "map": {
                   "name": {
-                    "type": "'ECDH'"
+                    "type": {
+                      "union": ["'ECDH'", "'ECDSA'"]
+                    }
                   },
                   "namedCurve": {
                     "type": "'P-256'"
@@ -330,7 +332,9 @@
           "type": {
             "map": {
               "name": {
-                "type": "'ECDH'"
+                "type": {
+                  "union": ["'ECDH'", "'ECDSA'"]
+                }
               },
               "namedCurve": {
                 "type": "'P-256'"

--- a/src/tabris/Crypto.ts
+++ b/src/tabris/Crypto.ts
@@ -1,6 +1,13 @@
 import NativeObject from './NativeObject';
 import {toValueString} from './Console';
-import CryptoKey, {Algorithm, AlgorithmECDH, AlgorithmHKDF, AlgorithmInternal, _CryptoKey} from './CryptoKey';
+import CryptoKey, {
+  Algorithm,
+  AlgorithmECDH,
+  AlgorithmECDSA,
+  AlgorithmHKDF,
+  AlgorithmInternal,
+  _CryptoKey
+} from './CryptoKey';
 import {allowOnlyKeys, allowOnlyValues, getBuffer, getCid, getNativeObject} from './util';
 import checkType from './checkType';
 
@@ -75,11 +82,11 @@ class SubtleCrypto {
     allowOnlyValues(format, ['spki', 'pkcs8', 'raw'], 'format');
     checkType(getBuffer(keyData), ArrayBuffer, {name: 'keyData'});
     if (typeof algorithm === 'string') {
-      allowOnlyValues(algorithm, ['ECDH', 'AES-GCM', 'HKDF'], 'algorithm');
+      allowOnlyValues(algorithm, ['AES-GCM', 'HKDF'], 'algorithm');
     } else {
       checkType(algorithm, Object, {name: 'algorithm'});
-      allowOnlyValues(algorithm.name, ['ECDH', 'AES-GCM'], 'algorithm.name');
-      if (algorithm.name === 'ECDH') {
+      allowOnlyValues(algorithm.name, ['ECDH', 'ECDSA', 'AES-GCM'], 'algorithm.name');
+      if (algorithm.name === 'ECDH' || algorithm.name === 'ECDSA') {
         allowOnlyKeys(algorithm, ['name', 'namedCurve']);
         allowOnlyValues(algorithm.namedCurve, ['P-256'], 'algorithm.namedCurve');
       } else {
@@ -210,7 +217,7 @@ class SubtleCrypto {
   }
 
   async generateKey(
-    algorithm: AlgorithmECDH,
+    algorithm: AlgorithmECDH | AlgorithmECDSA,
     extractable: boolean,
     keyUsages: string[]
   ): Promise<{privateKey: CryptoKey, publicKey: CryptoKey}> {
@@ -218,7 +225,7 @@ class SubtleCrypto {
       throw new TypeError(`Expected 3 arguments, got ${arguments.length}`);
     }
     allowOnlyKeys(algorithm, ['name', 'namedCurve']);
-    allowOnlyValues(algorithm.name, ['ECDH'], 'algorithm.name');
+    allowOnlyValues(algorithm.name, ['ECDH', 'ECDSA'], 'algorithm.name');
     allowOnlyValues(algorithm.namedCurve, ['P-256'], 'algorithm.namedCurve');
     checkType(extractable, Boolean, {name: 'extractable'});
     checkType(keyUsages, Array, {name: 'keyUsages'});

--- a/src/tabris/CryptoKey.ts
+++ b/src/tabris/CryptoKey.ts
@@ -2,7 +2,7 @@ import {TypedArray} from './Crypto';
 import NativeObject from './NativeObject';
 import {getBuffer, getCid, setNativeObject} from './util';
 
-export type AlgorithmInternal = AlgorithmHKDF | AlgorithmECDH | 'HKDF' | 'AES-GCM';
+export type AlgorithmInternal = AlgorithmHKDF | AlgorithmECDH | AlgorithmECDSA | 'HKDF' | 'AES-GCM';
 
 export type Algorithm = AlgorithmInternal | {name: 'AES-GCM'};
 
@@ -17,6 +17,11 @@ export type AlgorithmECDH = {
   name: 'ECDH',
   namedCurve: 'P-256',
   public?: CryptoKey
+};
+
+export type AlgorithmECDSA = {
+  name: 'ECDSA',
+  namedCurve: 'P-256'
 };
 
 export default class CryptoKey {
@@ -107,7 +112,7 @@ export class _CryptoKey extends NativeObject {
   }
 
   async generate(
-    algorithm: AlgorithmECDH,
+    algorithm: AlgorithmECDH | AlgorithmECDSA,
     extractable: boolean,
     keyUsages: string[]
   ): Promise<void> {

--- a/test/tabris/Crypto.test.ts
+++ b/test/tabris/Crypto.test.ts
@@ -647,7 +647,7 @@ describe('Crypto', function() {
     it('checks algorithm.name', async function() {
       (params[2] as any).name = 'foo';
       await expect(importKey())
-        .rejectedWith(TypeError, 'algorithm.name must be "ECDH" or "AES-GCM", got "foo"');
+        .rejectedWith(TypeError, 'algorithm.name must be "ECDH", "ECDSA" or "AES-GCM", got "foo"');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
     });
 
@@ -659,6 +659,14 @@ describe('Crypto', function() {
     });
 
     it('checks algorithm keys for ECDH', async function() {
+      (params[2] as any).foo = 'foo';
+      await expect(importKey())
+        .rejectedWith(TypeError, 'Object contains unexpected entry "foo"');
+      expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
+    });
+
+    it('checks algorithm keys for ECDSA', async function() {
+      (params[2] as any).name = 'ECDSA';
       (params[2] as any).foo = 'foo';
       await expect(importKey())
         .rejectedWith(TypeError, 'Object contains unexpected entry "foo"');
@@ -1069,7 +1077,7 @@ describe('Crypto', function() {
       // @ts-ignore
       params[0].name = 'foo';
       await expect(generateKey())
-        .rejectedWith(TypeError, 'algorithm.name must be "ECDH", got "foo"');
+        .rejectedWith(TypeError, 'algorithm.name must be "ECDH" or "ECDSA", got "foo"');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
     });
 


### PR DESCRIPTION
ECDSA and ECDH keys have the same internal representation on the native client but are used for different purposes - ECDSA for signing and ECDH for key exchange.

This commit adds support for ECDSA keys to the `SubtleCrypto` API. This prepares the way for supporting `crypto.subtle.sign()` and `crypto.subtle.verify()`.

It also removes `"ECDH"` from the allowed string values for the `algorithm` parameter of `crypto.subtle.importKey`, because for ECDH and ECDSA algorithms, always an object that includes `namedCurve` must be provided [1].

[1]: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey

<!--
Thank you for submitting a pull request for Tabris.js!

Please refer to the CONTRIBUTING.MD file for our coding conventions and more details on contributing.
-->

- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)


