### PR TITLE
Support signing and verification using ECDSA

### DIFF
--- a/doc/api/SubtleCrypto.json
+++ b/doc/api/SubtleCrypto.json
@@ -482,6 +482,89 @@
           "ArrayBuffer"
         ]
       }
+    },
+    "sign": {
+      "description": "Signs the given data. Currently only supports creating ECDSA signatures in DER format.",
+      "parameters": [
+        {
+          "name": "algorithm",
+          "type": {
+            "map": {
+              "name": {
+                "type": "'ECDSAinDERFormat'"
+              },
+              "hash": {
+                "type": "'SHA-256'"
+              }
+            }
+          }
+        },
+        {
+          "name": "key",
+          "type": "CryptoKey"
+        },
+        {
+          "name": "data",
+          "type": {
+            "union": [
+              "ArrayBuffer",
+              "TypedArray"
+            ]
+          }
+        }
+      ],
+      "returns": {
+        "interface": "Promise",
+        "generics": [
+          "ArrayBuffer"
+        ]
+      }
+    },
+    "verify": {
+      "description": "Verifies the given signature against the data. Currently only supports verifying ECDSA signatures in DER format.",
+      "parameters": [
+        {
+          "name": "algorithm",
+          "type": {
+            "map": {
+              "name": {
+                "type": "'ECDSAinDERFormat'"
+              },
+              "hash": {
+                "type": "'SHA-256'"
+              }
+            }
+          }
+        },
+        {
+          "name": "key",
+          "type": "CryptoKey"
+        },
+        {
+          "name": "signature",
+          "type": {
+            "union": [
+              "ArrayBuffer",
+              "TypedArray"
+            ]
+          }
+        },
+        {
+          "name": "data",
+          "type": {
+            "union": [
+              "ArrayBuffer",
+              "TypedArray"
+            ]
+          }
+        }
+      ],
+      "returns": {
+        "interface": "Promise",
+        "generics": [
+          "boolean"
+        ]
+      }
     }
   }
 }

--- a/snippets/crypto-sign.ts
+++ b/snippets/crypto-sign.ts
@@ -1,0 +1,33 @@
+import {contentView, crypto, Stack, tabris, TextView} from 'tabris';
+
+const stack = Stack({stretch: true, spacing: 8, padding: 16, alignment: 'stretchX'})
+  .appendTo(contentView);
+tabris.onLog(({message}) => stack.append(TextView({text: message})));
+
+(async function() {
+
+  // Generate a key pair for signing and verifying
+  const keyPair = await crypto.subtle.generateKey(
+    {name: 'ECDSA', namedCurve: 'P-256'},
+    true,
+    ['sign', 'verify']
+  );
+
+  // Sign a message
+  const message = await new Blob(['Message']).arrayBuffer();
+  const signature = await crypto.subtle.sign(
+    {name: 'ECDSAinDERFormat', hash: 'SHA-256'},
+    keyPair.privateKey,
+    message
+  );
+  console.log('Signature:', new Uint8Array(signature).join(', '));
+
+  // Verify the signature
+  const isValid = await crypto.subtle.verify(
+    {name: 'ECDSAinDERFormat', hash: 'SHA-256'},
+    keyPair.publicKey,
+    signature, message
+  );
+  console.log('Signature valid:', isValid);
+
+}());


### PR DESCRIPTION
Introduce the methods `crypto.subtle.sign()` and
`crypto.subtle.verify()` to create and verify ECDSA signatures.

Currently, only the combination of the algorithm `ECDSAinDERFormat` and
`SHA-256` hash is supported.

The algorithm `ECDSAinDERFormat` is similar to the `ECDSA` algorithm
used in `SubtleCrypto`, with the distinction that signature is encoded
in the DER format, diverging from the IEEE-P1363 format used in
`SubtleCrypto`.