### PR TITLE
Support generating ECDH keys in TEE with access control

### DIFF
--- a/snippets/crypto-sign.ts
+++ b/snippets/crypto-sign.ts
@@ -6,33 +6,11 @@ tabris.onLog(({message}) => stack.append(TextView({text: message})));
 
 (async function() {
   await signAndVerify();
-  await signAndVerifyWithKeysInTeeRequiringAuth();
+  await signAndVerify({inTee: true, usageRequiresAuth: true});
 }()).catch(console.error);
 
-async function signAndVerify() {
+async function signAndVerify({inTee, usageRequiresAuth} = {inTee: false, usageRequiresAuth: false}) {
   console.log('ECDSA signing/verification with generated keys:');
-  const generationAlgorithm = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
-  const signingAlgorithm = {name: 'ECDSAinDERFormat' as const, hash: 'SHA-256' as const};
-
-  // Generate a key pair for signing and verifying
-  const keyPair = await crypto.subtle.generateKey(generationAlgorithm, true, ['sign', 'verify']);
-
-  // Export the public key and import it back
-  const publicKeySpki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
-  const publicKey = await crypto.subtle.importKey('spki', publicKeySpki, generationAlgorithm, true, ['verify']);
-
-  // Sign a message
-  const message = await new Blob(['Message']).arrayBuffer();
-  const signature = await crypto.subtle.sign(signingAlgorithm, keyPair.privateKey, message);
-  console.log('Signature:', new Uint8Array(signature).join(', '));
-
-  // Verify the signature
-  const isValid = await crypto.subtle.verify(signingAlgorithm, publicKey, signature, message);
-  console.log('Signature valid:', isValid);
-}
-
-async function signAndVerifyWithKeysInTeeRequiringAuth() {
-  console.log('ECDSA signing/verification with keys generated in a trusted execution environment (TEE):');
   const generationAlgorithm = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
   const signingAlgorithm = {name: 'ECDSAinDERFormat' as const, hash: 'SHA-256' as const};
 
@@ -41,20 +19,24 @@ async function signAndVerifyWithKeysInTeeRequiringAuth() {
     generationAlgorithm,
     true,
     ['sign', 'verify'],
-    {inTee: true, usageRequiresAuth: true}
+    {inTee, usageRequiresAuth}
   );
 
-  // Export the private key and import it back
-  const privateKeyHandle = await crypto.subtle.exportKey('teeKeyHandle', keyPair.privateKey);
-  const algorithm = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
-  const privateKey = await crypto.subtle.importKey('teeKeyHandle', privateKeyHandle, algorithm, true, ['sign']);
+  let privateKeyImportedFromTee: CryptoKey;
+  if (inTee) {
+    // Export the private key and import it back
+    const privateKeyHandle = await crypto.subtle.exportKey('teeKeyHandle', keyPair.privateKey);
+    const alg = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
+    privateKeyImportedFromTee = await crypto.subtle.importKey('teeKeyHandle', privateKeyHandle, alg, true, ['sign']);
+  }
 
   // Export the public key and import it back
   const publicKeySpki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
-  const publicKey = await crypto.subtle.importKey('spki', publicKeySpki, algorithm, true, ['verify']);
+  const publicKey = await crypto.subtle.importKey('spki', publicKeySpki, generationAlgorithm, true, ['verify']);
 
   // Sign a message
   const message = await new Blob(['Message']).arrayBuffer();
+  const privateKey = inTee ? privateKeyImportedFromTee : keyPair.privateKey;
   const signature = await crypto.subtle.sign(signingAlgorithm, privateKey, message);
   console.log('Signature:', new Uint8Array(signature).join(', '));
 

--- a/src/tabris/Crypto.ts
+++ b/src/tabris/Crypto.ts
@@ -241,12 +241,6 @@ class SubtleCrypto {
       if ('usageRequiresAuth' in options) {
         checkType(options.usageRequiresAuth, Boolean, {name: 'options.usageRequiresAuth'});
       }
-      if (options.inTee && algorithm.name !== 'ECDSA') {
-        throw new TypeError('options.inTee is only supported for ECDSA keys');
-      }
-      if (options.usageRequiresAuth && algorithm.name !== 'ECDSA') {
-        throw new TypeError('options.usageRequiresAuth is only supported for ECDSA keys');
-      }
       if (options.usageRequiresAuth && !options.inTee) {
         throw new TypeError('options.usageRequiresAuth is only supported for keys in TEE');
       }

--- a/test/tabris/Crypto.test.ts
+++ b/test/tabris/Crypto.test.ts
@@ -1124,22 +1124,6 @@ describe('Crypto', function() {
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
     });
 
-    it('rejects options.inTee when algorithm name is not ECDSA', async function() {
-      params[0] = {name: 'ECDH', namedCurve: 'P-256'};
-      params[3] = {inTee: true};
-      await expect(generateKey())
-        .rejectedWith(TypeError, 'options.inTee is only supported for ECDSA keys');
-      expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
-    });
-
-    it('rejects options.usageRequiresAuth when algorithm name is not ECDSA', async function() {
-      params[0] = {name: 'ECDH', namedCurve: 'P-256'};
-      params[3] = {usageRequiresAuth: true};
-      await expect(generateKey())
-        .rejectedWith(TypeError, 'options.usageRequiresAuth is only supported for ECDSA keys');
-      expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
-    });
-
     it('rejects options.usageRequiresAuth when options.inTee is not set', async function() {
       params[3] = {usageRequiresAuth: true};
       await expect(generateKey())


### PR DESCRIPTION
Previously, the options `inTee` and `usageRequiresAuth` of `generateKey()` were only supported for ECDSA keys. This commit extends the support for those options to ECDH keys as well.

It also provides an example for deriving AES keys from ECDH keys and encrypting/decrypting data with them, using the new options.

Boyscouting: reduce code duplication in the `crypto-sign.ts` snippet.
