### PR TITLE
Signing and key derivation: support configuring auth prompt texts

### DIFF
--- a/doc/api/SubtleCrypto.json
+++ b/doc/api/SubtleCrypto.json
@@ -84,6 +84,16 @@
           {
             "name": "keyUsages",
             "type": "string[]"
+          },
+          {
+            "name": "options",
+            "optional": true,
+            "type": {
+              "map": {
+                "authPromptTitle": { "type": "string", "optional": true },
+                "authPromptMessage": { "type": "string", "optional": true }
+              }
+            }
           }
         ],
         "returns": {
@@ -193,6 +203,16 @@
           {
             "name": "length",
             "type": "number"
+          },
+          {
+            "name": "options",
+            "optional": true,
+            "type": {
+              "map": {
+                "authPromptTitle": { "type": "string", "optional": true },
+                "authPromptMessage": { "type": "string", "optional": true }
+              }
+            }
           }
         ],
         "returns": {
@@ -522,6 +542,16 @@
               "ArrayBuffer",
               "TypedArray"
             ]
+          }
+        },
+        {
+          "name": "options",
+          "optional": true,
+          "type": {
+            "map": {
+              "authPromptTitle": { "type": "string", "optional": true },
+              "authPromptMessage": { "type": "string", "optional": true }
+            }
           }
         }
       ],

--- a/src/tabris/CryptoKey.ts
+++ b/src/tabris/CryptoKey.ts
@@ -81,7 +81,9 @@ export class _CryptoKey extends NativeObject {
     baseKey: CryptoKey,
     derivedKeyAlgorithm: {name: string, length: number},
     extractable: boolean,
-    keyUsages: string[]
+    keyUsages: string[],
+    authPromptTitle?: string,
+    authPromptMessage?: string
   ): Promise<void> {
     return new Promise((onSuccess, onError) => {
       if (typeof algorithm === 'string') {
@@ -94,6 +96,8 @@ export class _CryptoKey extends NativeObject {
           derivedKeyAlgorithm,
           extractable,
           keyUsages,
+          authPromptTitle,
+          authPromptMessage,
           onSuccess,
           onError: wrapErrorCb(onError)
         });
@@ -104,6 +108,8 @@ export class _CryptoKey extends NativeObject {
           derivedKeyAlgorithm,
           extractable,
           keyUsages,
+          authPromptTitle,
+          authPromptMessage,
           onSuccess,
           onError: wrapErrorCb(onError)
         });

--- a/test/tabris/Crypto.test.ts
+++ b/test/tabris/Crypto.test.ts
@@ -319,7 +319,7 @@ describe('Crypto', function() {
     it('checks parameter length', async function() {
       params.pop();
       await expect(deriveKey())
-        .rejectedWith(TypeError, 'Expected 5 arguments, got 4');
+        .rejectedWith(TypeError, 'Expected at least 5 arguments, got 4');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
     });
 
@@ -391,6 +391,20 @@ describe('Crypto', function() {
       await expect(deriveKey())
         .rejectedWith(TypeError, 'Expected derivedKeyAlgorithm.length to be a number, got string.');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
+    });
+
+    it('checks options.authPromptTitle', async function() {
+      params[5] = {authPromptTitle: null};
+      await expect(deriveKey())
+        .rejectedWith(TypeError, 'Expected options.authPromptTitle to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
+    });
+
+    it('checks options.authPromptMessage', async function() {
+      params[5] = {authPromptMessage: null};
+      await expect(deriveKey())
+        .rejectedWith(TypeError, 'Expected options.authPromptMessage to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
     });
 
   });
@@ -502,7 +516,7 @@ describe('Crypto', function() {
 
     it('checks parameter length', async function() {
       params.pop();
-      await expect(deriveBits()).rejectedWith(TypeError, 'Expected 3 arguments, got 2');
+      await expect(deriveBits()).rejectedWith(TypeError, 'Expected at least 3 arguments, got 2');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
     });
 
@@ -524,6 +538,20 @@ describe('Crypto', function() {
       await expect(deriveBits())
         .rejectedWith(TypeError, 'Expected baseKey to be of type CryptoKey, got null.');
       expect(client.calls({op: 'create', type: 'tabris.CryptoKey'}).length).to.equal(0);
+    });
+
+    it('checks options.authPromptTitle', async function() {
+      params[3] = {authPromptTitle: null};
+      await expect(deriveBits())
+        .rejectedWith(TypeError, 'Expected options.authPromptTitle to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
+    });
+
+    it('checks options.authPromptMessage', async function() {
+      params[3] = {authPromptMessage: null};
+      await expect(deriveBits())
+        .rejectedWith(TypeError, 'Expected options.authPromptMessage to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
     });
 
   });
@@ -1189,7 +1217,7 @@ describe('Crypto', function() {
     it('checks parameter length', async function() {
       params.pop();
       await expect(sign())
-        .rejectedWith(TypeError, 'Expected 3 arguments, got 2');
+        .rejectedWith(TypeError, 'Expected at least 3 arguments, got 2');
       expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
     });
 
@@ -1220,6 +1248,21 @@ describe('Crypto', function() {
         .rejectedWith(TypeError, 'Expected data to be of type ArrayBuffer, got null');
       expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
     });
+
+    it('checks options.authPromptTitle', async function() {
+      params[3] = {authPromptTitle: null};
+      await expect(sign())
+        .rejectedWith(TypeError, 'Expected options.authPromptTitle to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
+    });
+
+    it('checks options.authPromptMessage', async function() {
+      params[3] = {authPromptMessage: null};
+      await expect(sign())
+        .rejectedWith(TypeError, 'Expected options.authPromptMessage to be a string, got null.');
+      expect(client.calls({op: 'call', method: 'subtleSign'}).length).to.equal(0);
+    });
+
   });
 
   describe('subtle.verify()', function() {


### PR DESCRIPTION
For keys that require authentication, a prompt is shown to the user on Android to confirm the operation. The texts were previously hard-coded. This change allows to configure them via an options object passed to `subtle.sign()`, `subtle.deriveKey()` and `subtle.deriveBits()`. When the key is not protected by a user authentication requirement, the authentication options are ignored.
