### PR TITLE
EC keys: consolidate API for handling keys in TEE

### DIFF
--- a/doc/api/SubtleCrypto.json
+++ b/doc/api/SubtleCrypto.json
@@ -287,8 +287,7 @@
             "union": [
               "'spki'",
               "'pkcs8'",
-              "'raw'",
-              "'teeKeyHandle'"
+              "'raw'"
             ]
           }
         },
@@ -346,7 +345,7 @@
       }
     },
     "generateKey": {
-      "description": "Generates new keys. Currently only supports the Elliptic Curve Diffie-Hellman (ECDH) algorithm to generate key pairs.",
+      "description": "Generates new keys. Currently only supports the Elliptic Curve Diffie-Hellman (ECDH) and Elliptic Curve Digital Signature Algorithm (ECDSA) algorithms to generate key pairs. When `extractable` is set to `true`, the raw key material can be exported using `exportKey`. When `extractable` is set to `false`, for ECDSA and ECDH keys `exportKey` returns an opaque handle to the key in the device's trusted execution environment, and throws for other key formats.",
       "parameters": [
         {
           "name": "algorithm",
@@ -376,7 +375,6 @@
           "optional": true,
           "type": {
             "map": {
-              "inTee": { "type": "boolean", "optional": true },
               "usageRequiresAuth": { "type": "boolean", "optional": true }
             }
           }
@@ -491,15 +489,14 @@
       }
     },
     "exportKey": {
-      "description": "Converts a CryptoKey instances into a portable format. To export a key, the key must have extractable set to true. Supports the spki format or raw bytes.",
+      "description": "Converts `CryptoKey` instances into a portable format. If the key's `extractable` is set to `true`, returns the raw key material in SPKI format or as raw bytes. If the key's `extractable` is set to `false`, for ECDSA and ECDH keys returns an opaque handle to the key in the device's trusted execution environment, and throws for other key formats.",
       "parameters": [
         {
           "name": "format",
           "type": {
             "union": [
               "'raw'",
-              "'spki'",
-              "'teeKeyHandle'"
+              "'spki'"
             ]
           }
         },

--- a/snippets/crypto-derive.ts
+++ b/snippets/crypto-derive.ts
@@ -8,7 +8,7 @@ tabris.onLog(({message}) => stack.append(TextView({text: message})));
 (async () => {
   await importAndDerive();
   await generateDeriveEncryptAndDecrypt();
-  await generateDeriveEncryptAndDecrypt({inTee: true, usageRequiresAuth: true});
+  await generateDeriveEncryptAndDecrypt({extractable: false, usageRequiresAuth: true});
 })().catch(console.error);
 
 async function importAndDerive() {
@@ -103,7 +103,10 @@ async function importAndDerive() {
   }
 }
 
-async function generateDeriveEncryptAndDecrypt({inTee, usageRequiresAuth} = {inTee: false, usageRequiresAuth: false}) {
+async function generateDeriveEncryptAndDecrypt({extractable, usageRequiresAuth} = {
+  extractable: true,
+  usageRequiresAuth: false
+}) {
   const ecdhP256 = {name: 'ECDH' as const, namedCurve: 'P-256' as const};
   const aesGcm = {name: 'AES-GCM' as const};
 
@@ -111,7 +114,7 @@ async function generateDeriveEncryptAndDecrypt({inTee, usageRequiresAuth} = {inT
   const alicesKeyPair = await crypto.subtle.generateKey(ecdhP256, true, ['deriveBits']);
 
   // Generate Bob's ECDH key pair
-  const bobsKeyPair = await crypto.subtle.generateKey(ecdhP256, true, ['deriveBits'], {inTee, usageRequiresAuth});
+  const bobsKeyPair = await crypto.subtle.generateKey(ecdhP256, extractable, ['deriveBits'], {usageRequiresAuth});
 
   // Derive Alice's AES key
   const alicesAesKey = await deriveAesKey(bobsKeyPair.publicKey, alicesKeyPair.privateKey, 'encrypt');

--- a/snippets/crypto-sign.ts
+++ b/snippets/crypto-sign.ts
@@ -6,10 +6,10 @@ tabris.onLog(({message}) => stack.append(TextView({text: message})));
 
 (async function() {
   await signAndVerify();
-  await signAndVerify({inTee: true, usageRequiresAuth: true});
+  await signAndVerify({extractable: false, usageRequiresAuth: true});
 }()).catch(console.error);
 
-async function signAndVerify({inTee, usageRequiresAuth} = {inTee: false, usageRequiresAuth: false}) {
+async function signAndVerify({extractable, usageRequiresAuth} = {extractable: true, usageRequiresAuth: false}) {
   console.log('ECDSA signing/verification with generated keys:');
   const generationAlgorithm = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
   const signingAlgorithm = {name: 'ECDSAinDERFormat' as const, hash: 'SHA-256' as const};
@@ -17,26 +17,26 @@ async function signAndVerify({inTee, usageRequiresAuth} = {inTee: false, usageRe
   // Generate a key pair for signing and verifying
   const keyPair = await crypto.subtle.generateKey(
     generationAlgorithm,
-    true,
+    extractable,
     ['sign', 'verify'],
-    {inTee, usageRequiresAuth}
+    {usageRequiresAuth}
   );
 
   let privateKeyImportedFromTee: CryptoKey;
-  if (inTee) {
-    // Export the private key and import it back
-    const privateKeyHandle = await crypto.subtle.exportKey('teeKeyHandle', keyPair.privateKey);
+  if (!extractable) {
+    // Export a handle of the private key stored in the Trusted Execution Environment and import it back
+    const privateKeyHandle = await crypto.subtle.exportKey('raw', keyPair.privateKey);
     const alg = {name: 'ECDSA' as const, namedCurve: 'P-256' as const};
-    privateKeyImportedFromTee = await crypto.subtle.importKey('teeKeyHandle', privateKeyHandle, alg, true, ['sign']);
+    privateKeyImportedFromTee = await crypto.subtle.importKey('raw', privateKeyHandle, alg, extractable, ['sign']);
   }
 
   // Export the public key and import it back
   const publicKeySpki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
-  const publicKey = await crypto.subtle.importKey('spki', publicKeySpki, generationAlgorithm, true, ['verify']);
+  const publicKey = await crypto.subtle.importKey('spki', publicKeySpki, generationAlgorithm, extractable, ['verify']);
 
   // Sign a message
   const message = await new Blob(['Message']).arrayBuffer();
-  const privateKey = inTee ? privateKeyImportedFromTee : keyPair.privateKey;
+  const privateKey = !extractable ? privateKeyImportedFromTee : keyPair.privateKey;
   const signature = await crypto.subtle.sign(signingAlgorithm, privateKey, message);
   console.log('Signature:', new Uint8Array(signature).join(', '));
 

--- a/src/tabris/CryptoKey.ts
+++ b/src/tabris/CryptoKey.ts
@@ -24,7 +24,7 @@ export type AlgorithmECDSA = {
   namedCurve: 'P-256'
 };
 
-export type GenerateKeyOptions = { inTee?: boolean, usageRequiresAuth?: boolean };
+export type GenerateKeyOptions = { usageRequiresAuth?: boolean };
 
 export default class CryptoKey {
 
@@ -123,7 +123,6 @@ export class _CryptoKey extends NativeObject {
     algorithm: AlgorithmECDH | AlgorithmECDSA,
     extractable: boolean,
     keyUsages: string[],
-    inTee?: boolean,
     usageRequiresAuth?: boolean
   ): Promise<void> {
     return new Promise((onSuccess, onError) =>
@@ -131,7 +130,6 @@ export class _CryptoKey extends NativeObject {
         algorithm,
         extractable,
         keyUsages,
-        inTee,
         usageRequiresAuth,
         onSuccess,
         onError: wrapErrorCb(onError)


### PR DESCRIPTION
The `inTee` option and the `teeKeyHandle` format provided a way to create keys in the TEE and export them as opaque handles. While this API made it transparent when a key is really stored in the TEE, it was not convenient in practice, as it required the application to conduct specific checks for hardware support on Android in order to decide whether to store the key in TEE or not.

This commit removes the `inTee` option. ECDSA and ECDH keys with `extractable` set to `false` are now generated in the TEE by the platform when the device supports it. When the device does not support it, the key is generated in software. In practice, this means that non-extractable EC* keys are always generated in TEE on iOS, and on Android only when the device supports it.

The `"teeKeyHandle"` format has also been removed. The `exportKey` method called for EC* keys with `extractable` set to `false` and the format `"raw"` now returns an opaque handle to the key in the TEE instead of throwing.
