### PR TITLE
Add support for universal links (iOS) and app links (Android)

### DIFF
--- a/doc/api/app.json
+++ b/doc/api/app.json
@@ -145,6 +145,15 @@
       "platforms": {
         "ios": false
       }
+    },
+    "continueWebActivity": {
+      "description": "Fired when the app is launched via a universal link (iOS) or app link (Android). This event allows the app to handle universal/app links opened in another app.",
+      "parameters": {
+        "webpageURL": {
+          "description": "The URL that was used to launch or resume the app, including path and query parameters.",
+          "type": "string"
+        }
+      }
     }
   },
   "methods": {

--- a/src/tabris/App.js
+++ b/src/tabris/App.js
@@ -234,7 +234,8 @@ NativeObject.defineEvents(App.prototype, {
   terminate: {native: true},
   keyPress: {native: true},
   backNavigation: {native: true},
-  certificatesReceived: {native: true}
+  certificatesReceived: {native: true},
+  continueWebActivity: {native: true}
 });
 
 export function create() {


### PR DESCRIPTION
This commit adds the `continueWebActivity` event to the App class, allowing developers to react to universal links on iOS [1] and app links on Android [2]. The event includes a parameter `webpageURL` containing the URL that was used to launch the app, including path and query parameters.

[1]: https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app
[2]: https://developer.android.com/training/app-links

<!--
Thank you for submitting a pull request for Tabris.js!

Please refer to the CONTRIBUTING.MD file for our coding conventions and more details on contributing.
-->

- [x] Code is up-to-date with current `master`
- [x] Code is provided under the terms of the [Tabris.js license](https://github.com/EclipseSource/tabris-js/blob/master/LICENSE)
